### PR TITLE
[fix] Compiler error due to missing header file

### DIFF
--- a/src/modules/RobileMasterBattery.cpp
+++ b/src/modules/RobileMasterBattery.cpp
@@ -41,6 +41,7 @@
  *
  ******************************************************************************/
 
+#include <iostream>
 #include "kelo_tulip/modules/RobileMasterBattery.h"
 
 namespace kelo {


### PR DESCRIPTION
This PR fixes the compiler errors due to the missing `iostream` header which is required for the `std::cout` calls in the `RobileMasterBattery.cpp` file.