### PR TITLE
Add missing variables to KeloDriveAPI and RobileMasterBattery

### DIFF
--- a/include/kelo_tulip/KeloDriveAPI.h
+++ b/include/kelo_tulip/KeloDriveAPI.h
@@ -104,6 +104,7 @@ typedef struct PACKED{
   float			gyro_z;				// IMU gyro Z-axis in rad/s
   float			temperature_imu;	// IMU temperature in K	
   float			pressure;			// barometric pressure in Pa absolute
+  float			current_in;			// current input
 }txpdo1_t;
 
 /* SMARTWHEEL SETPOINT MODES

--- a/include/kelo_tulip/modules/RobileMasterBattery.h
+++ b/include/kelo_tulip/modules/RobileMasterBattery.h
@@ -108,6 +108,7 @@ struct __attribute__((packed)) RobileMasterBatteryProcessDataOutput {
   uint32_t      Command1;
   uint32_t      Command2;
   uint16_t      Shutdown;
+  uint16_t      PwrDeviceId;
 };
 
 } // namespace kelp


### PR DESCRIPTION
the structs for both KeloDrive and RobileMasterBattery are missing a variable each, which are defined in the PDOs of the respective slaves.
This can be verified by running `slaveinfo <ifname> -map`.